### PR TITLE
Public request tx history

### DIFF
--- a/dist/types.d.ts
+++ b/dist/types.d.ts
@@ -1906,6 +1906,8 @@ export class BaseConsensus extends Observable {
         network: Network,
     );
     public subscribe(subscription: Subscription): void;
+    public requestTransactionHistory(address: Address): Promise<Array<{transaction: Transaction, header: BlockHeader}>>;
+    public requestTransactionReceipts(address: Address): Promise<TransactionReceipt[]>;
 }
 
 export class FullChain extends BaseChain {

--- a/src/main/generic/consensus/BaseConsensus.js
+++ b/src/main/generic/consensus/BaseConsensus.js
@@ -307,9 +307,8 @@ class BaseConsensus extends Observable {
     /**
      * @param {Address} address
      * @returns {Promise.<Array.<TransactionReceipt>>}
-     * @protected
      */
-    async _requestTransactionReceipts(address) {
+    async requestTransactionReceipts(address) {
         const agents = [];
         for (const agent of this._agents.valueIterator()) {
             if (agent.synced
@@ -335,11 +334,10 @@ class BaseConsensus extends Observable {
     /**
      * @param {Address} address
      * @returns {Promise.<Array.<{transaction: Transaction, header: BlockHeader}>>}
-     * @protected
      */
-    async _requestTransactionHistory(address) {
+    async requestTransactionHistory(address) {
         // 1. Get transaction receipts.
-        const receipts = await this._requestTransactionReceipts(address);
+        const receipts = await this.requestTransactionReceipts(address);
 
         // 2. Request proofs for missing blocks.
         /** @type {Array.<Promise.<Block>>} */


### PR DESCRIPTION
## Pull request checklist

- [X] All tests pass. Demo project builds and runs.
- [X] I have resolved any merge conflicts.

## What's in this pull request?

> Make `_requestTransactionHistory` and `_requestTransactionReceipts` in `BaseConsensus` public methods as their purpose is to be used from outside. `_requestTransactionHistory` is actually not used within the core at all. Also making `_requestTransactionReceipts` public as it is used in the frontend instead of `_requestTransactionHistory` as a performance optimization in situations when only the information whether transactions are present is relevant without the need to know the full transaction history.
> Also changing `_requestTransactionProof` and `_requestBlockProof` to be public could be considered but currently our frontends don't use these methods.
>
> Additionally, I reordered the methods of `BaseConsensus` to move the now public methods and the already public getters before the private methods.
