### PR TITLE
JsonRpcServer: Add WS endpoint to stream blocks

### DIFF
--- a/clients/nodejs/modules/JsonRpcServer.js
+++ b/clients/nodejs/modules/JsonRpcServer.js
@@ -652,9 +652,9 @@ class JsonRpcServer {
             });
         }
 
-        // Push every new block to client
+        // Listen for new blocks and push them to the client
         const listener = this._blockchain.on('head-changed', async () => {
-            const block = await this._getBlockByNumber(this._blockchain.height);
+            const block = this._blockchain.head;
             if (!block) return;
             const obj = await this._blockToObj(block, includeTransactions);
             ws.send(JSON.stringify(obj));

--- a/clients/nodejs/modules/JsonRpcServer.js
+++ b/clients/nodejs/modules/JsonRpcServer.js
@@ -740,7 +740,7 @@ class JsonRpcServer {
      * @private
      */
     async _blockToObj(block, includeTransactions = false) {
-        return {
+        const out = {
             number: block.height,
             hash: block.hash().toHex(),
             pow: (await block.pow()).toHex(),
@@ -748,16 +748,20 @@ class JsonRpcServer {
             nonce: block.nonce,
             bodyHash: block.bodyHash.toHex(),
             accountsHash: block.accountsHash.toHex(),
-            miner: block.minerAddr.toHex(),
-            minerAddress: block.minerAddr.toUserFriendlyAddress(),
             difficulty: block.difficulty,
-            extraData: Nimiq.BufferUtils.toHex(block.body.extraData),
-            size: block.serializedSize,
             timestamp: block.timestamp,
-            transactions: includeTransactions
-                ? block.transactions.map((tx, i) => this._transactionToObj(tx, block, i))
-                : block.transactions.map((tx) => tx.hash().toHex())
         };
+
+        if (this._network._networkConfig._services.provided > Nimiq.Services.NANO) {
+            out.miner = block.minerAddr.toHex();
+            out.minerAddress = block.minerAddr.toUserFriendlyAddress();
+            out.extraData = Nimiq.BufferUtils.toHex(block.body.extraData),
+            out.size = block.serializedSize;
+            out.transactions = includeTransactions
+                ? block.transactions.map((tx, i) => this._transactionToObj(tx, block, i))
+                : block.transactions.map((tx) => tx.hash().toHex());
+        }
+        return out;
     }
 
     /**

--- a/clients/nodejs/modules/JsonRpcServer.js
+++ b/clients/nodejs/modules/JsonRpcServer.js
@@ -944,7 +944,7 @@ class JsonRpcServer {
 
         const methodRes = this._wsMethods.get(pathname);
 
-        const query = urlObject.searchParams;
+        const query = new URLSearchParams(urlObject.search);
         const wss = new WebSocket.Server({ noServer: true });
         wss.handleUpgrade(req, socket, head,
             ws => methodRes(ws, query, req));

--- a/clients/nodejs/remote.js
+++ b/clients/nodejs/remote.js
@@ -261,11 +261,13 @@ function displayBlock(block, hashOrNumber) {
     console.log(`Number      | ${block.number}`);
     console.log(`PoW-Hash    | ${block.pow}`);
     console.log(`Parent-Hash | ${block.parentHash}`);
-    console.log(`Miner       | ${block.minerAddress}`);
     console.log(`Timestamp   | ${new Date(block.timestamp * 1000).toString()}`);
-    console.log(`Size        | ${block.size} bytes (${block.transactions.length} transactions)`);
     console.log(`Difficulty  | ${block.difficulty}`);
-    console.log(`Extra       | ${block.extraData || null}`);
+    if (block.minerAddress) {
+        console.log(`Size        | ${block.size} bytes (${block.transactions.length} transactions)`);
+        console.log(`Miner       | ${block.minerAddress}`);
+        console.log(`Extra       | ${block.extraData || null}`);
+    }
 }
 
 async function displayAccount(account, name, head) {


### PR DESCRIPTION
## Pull request checklist

- [x] All tests pass. Demo project builds and runs.
- [x] I have resolved any merge conflicts.
- [ ] Wait for #491 or similar to be merged

## What's in this pull request?

Adds support for streaming new blocks on the chain from the JSON-RPC server to a client.

More technical:

 - Adds support for WebSocket endpoints to JsonRpcServer
 - WS endpoints are free-form, not strictly JSON-RPC
 - Adds a `/streamBlocks` WS endpoint
    - It sends out every new block

#### Example of `streamBlocks`

Nimiq node getting new blocks
<img width="847" alt="image" src="https://user-images.githubusercontent.com/21371810/55758720-d98c0e80-5a57-11e9-89a6-257d9e2f6010.png">

WS Client receiving them
<img width="672" alt="image" src="https://user-images.githubusercontent.com/21371810/55758693-c8430200-5a57-11e9-98b0-7458a9dbcf0c.png">