### PR TITLE
Add block long polling to JsonRpcServer

### DIFF
--- a/clients/nodejs/modules/Config.js
+++ b/clients/nodejs/modules/Config.js
@@ -63,7 +63,8 @@ const DEFAULT_CONFIG = /** @type {Config} */ {
         allowip: null,
         methods: null,
         username: null,
-        password: null
+        password: null,
+        pollTimeout: 5000
     },
     uiServer: {
         enabled: false,
@@ -134,7 +135,8 @@ const CONFIG_TYPES = {
             allowip: {type: 'mixed', types: ['string', {type: 'array', inner: 'string'}]},
             methods: {type: 'array', inner: 'string'},
             username: 'string',
-            password: 'string'
+            password: 'string',
+            pollTimeout: 'number',
         }
     },
     uiServer: {


### PR DESCRIPTION
## What's in this pull request?

This introduces support for streaming new blocks on the chain from the JSON-RPC server to a client.
By using the new `wait` parameter to the `getBlockByNumber` function, the client can do HTTP long polling.

The default timeout is 5s, TODO increase?