### PR TITLE
Upgrade to istanbul-api

### DIFF
--- a/package.json
+++ b/package.json
@@ -98,7 +98,7 @@
     "gulp-uglify-es": "^1.0.1",
     "gulp-util": "^3.0.8",
     "gulp-watch": "^5.0.0",
-    "istanbul": "^1.1.0-alpha.1",
+    "istanbul-api": "^2.1.6",
     "jasmine": "^3.1.0",
     "jasmine-console-reporter": "^3.0.0",
     "jasmine-core": "^3.1.0",


### PR DESCRIPTION
## Pull request checklist

- [ ] All tests pass. Demo project builds and runs.
- [x] I have resolved any merge conflicts.

## What's in this pull request?

Replace `istanbul` (deprecated) with `istanbul-api` in package.json

## Why?

`gulpfile.js` depends on `istanbul-api`, but currently only `istanbul` is imported.

https://github.com/nimiq/core-js/blob/bbbc40620d6f85d80cb722111ee90af615ccce92/gulpfile.js#L7
https://github.com/nimiq/core-js/blob/bbbc40620d6f85d80cb722111ee90af615ccce92/package.json#L101

As a result, the build fails with package managers without flat `node_modules` (such as [pnpm.js.org](https://pnpm.js.org))