### PR TITLE
Add streaming support to JsonRpcServer

### DIFF
--- a/clients/nodejs/modules/JsonRpcServer.js
+++ b/clients/nodejs/modules/JsonRpcServer.js
@@ -73,7 +73,7 @@ class JsonRpcServer {
         
         this.http.on('upgrade', async (req, socket, head) => {
             if (!JsonRpcServer._authenticate(req, null, config.username, config.password, /*raw*/ true))
-                socket.close();
+                socket.destroy();
     
             const wss = new WebSocket.Server({ noServer: true });
             await wss.handleUpgrade(req, socket, head, ws => {


### PR DESCRIPTION
## Pull request checklist

- [x] My Git history is clean
- [ ] My code is clean
- [ ] stream-blocks client

## What's in this pull request?

 * Implements JSON-RPC over WS (via upgrade)
 * Implements Ethereum's RPC Pub/Sub ([link](https://github.com/ethereum/go-ethereum/wiki/RPC-PUB-SUB))
 * Adds support for streaming new blocks on the chain from the JSON-RPC server to a client

### Example

![image](https://user-images.githubusercontent.com/21371810/57428653-a640c900-7229-11e9-936d-3da176667852.png)
