### PR TITLE
Set Travis CI badge to master branch

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Nimiq Blockchain [![Build Status](https://travis-ci.org/nimiq/core-js.svg)](https://travis-ci.org/nimiq/core-js)
+# Nimiq Blockchain [![Build Status](https://travis-ci.org/nimiq/core-js.svg?branch=master)](https://travis-ci.org/nimiq/core-js)
 
 **[Nimiq](https://nimiq.com/)** is a frictionless payment protocol for the web.
 


### PR DESCRIPTION
## What's in this pull request?

By default, Travis CI now shows the build status of the newest commit in the repo, regardless of which branch. 🙄

This change changes the badge to display the master branch status only.