### PR TITLE
Remove ineffective legacy class registrations

### DIFF
--- a/src/main/generic/network/message/GetTransactionReceiptsByAddressMessage.js
+++ b/src/main/generic/network/message/GetTransactionReceiptsByAddressMessage.js
@@ -55,6 +55,3 @@ class GetTransactionReceiptsByAddressMessage extends Message {
     }
 }
 Class.register(GetTransactionReceiptsByAddressMessage);
-/** @deprecated */
-GetTransactionReceiptsMessage = GetTransactionReceiptsByAddressMessage;
-Class.register(GetTransactionReceiptsMessage);

--- a/src/main/generic/network/message/GetTransactionsProofByAddressesMessage.js
+++ b/src/main/generic/network/message/GetTransactionsProofByAddressesMessage.js
@@ -69,6 +69,3 @@ class GetTransactionsProofByAddressesMessage extends Message {
  */
 GetTransactionsProofByAddressesMessage.ADDRESSES_MAX_COUNT = 255;
 Class.register(GetTransactionsProofByAddressesMessage);
-/** @deprecated */
-GetTransactionsProofMessage = GetTransactionsProofByAddressesMessage;
-Class.register(GetTransactionsProofMessage);


### PR DESCRIPTION
Fixes #508.

## 1. Remove ineffective legacy class registrations
The registration in the `Class` class is done by `<class>.name`, which is the name that the class is created with, not the name of the variable that the class is currently assigned as. Thus the assignements under the deprecated variable names actually only assigned the same class to the same name for a second time, overwriting the first registration. (I am not _100%_ sure here, but I think this is what happens and the deprecated registrations have no effect)

(If you really need to keep the legacy classes around, I suggest to create a new class with the legacy name that `extends` the new class.)

## 2. The legacy variable assignments are a syntax errors in strict/module JS
Omitting a `let` or `const` in front of the legacy variable (which has not been defined before) is a syntax error in strict (and thus ES6 module) javascript. This is the actual error that #508 is about.