### PR TITLE
Hot-reload SSL key and cert

### DIFF
--- a/src/main/platform/nodejs/index.prefix.js
+++ b/src/main/platform/nodejs/index.prefix.js
@@ -5,6 +5,7 @@ const JDB = require('@nimiq/jungle-db');
 const fs = require('fs');
 const https = require('https');
 const http = require('http');
+const tls = require('tls');
 let cpuid;
 try {
     cpuid = require('cpuid-git');


### PR DESCRIPTION
## Pull request checklist

- [x] All tests pass. Demo project builds and runs.
- [x] I have resolved any merge conflicts.

## What's in this pull request?
This PR adds support for hot-reloading SSL key and cert whenever those change, without having to drop connections. This is frequently required when using e.g. LetsEncrypt certificates, as those expire after 3 months. While LetsEncrypt's certbot is frequently used to refresh certificates automatically, restarting the Nimiq node is often forgotten and thus the new certificates aren't actually used.

This PR uses the [`SNICallback` option in `https.createServer()`](https://nodejs.org/docs/latest/api/tls.html#tls_tls_createserver_options_secureconnectionlistener) to always serve up-to-date key and cert to new connections. This option is supported in Node since the beginning, so there is no backwards-compatibility problem with the Node version. [SNI has been supported as a TLS extension by basically all browsers for a long time](https://en.m.wikipedia.org/wiki/Server_Name_Indication#Support). Unsupporting browsers still get the static `key` and `cert` that is given to the `createServer()` method as an initial option.

Node v11 additionally introduced the [`server.setSecureContext()`](https://nodejs.org/docs/latest/api/tls.html#tls_server_setsecurecontext_options) method that replaces the server's security context for all connections (not just SNI-aware) without dropping connections, but since Nimiq currently supports Node as low as v8, this is not yet an option to add. It could be used with feature- or version-detection, though.

## How this PR was tested
1. Start a local full Nimiq node (WSS, testnet, port 8443) with an expired cert.
2. Open browser to localhost:8443, browser complains about bad cert - cert details show loaded cert details (expired).
3. Replace the cert file with the new cert in the filesystem, while _not_ restarting the node process.
4. The node process stays up, debug-logs "(Re-)Loading SSL config" as expected.
5. Reload the browser tab - the new cert is loaded (still displays cert error because of self-signature, but the expiry date is the new one). (Sometimes the browser caches the expired cert. Opening the URL in an incognito window always displays the correct cert details.)
6. The node process did not crash/restart.