### PR TITLE
Client volatile fixes

### DIFF
--- a/src/main/generic/api/Configuration.js
+++ b/src/main/generic/api/Configuration.js
@@ -261,7 +261,7 @@ Client.ConfigurationBuilder = class ConfigurationBuilder {
 
     _requiredSet(val, name, ...values) {
         if (!val) throw new Error(`${name} is required`);
-        if (!values.includes(val)) throw new Error(`Type of ${name} must one of: ${values.join(', ')}`);
+        if (!values.includes(val)) throw new Error(`${name} must be one of: ${values.join(', ')}`);
         return val;
     }
 };

--- a/src/main/generic/api/Configuration.js
+++ b/src/main/generic/api/Configuration.js
@@ -216,7 +216,7 @@ Client.ConfigurationBuilder = class ConfigurationBuilder {
      * @returns {Client.Configuration} The configuration object to create a client with.
      */
     build() {
-        if (!this._volatile && this._features.contains(Client.Feature.LOCAL_HISTORY)) {
+        if (this._volatile && this._features.contains(Client.Feature.LOCAL_HISTORY)) {
             throw new Error('Local history is not available with volatile storage');
         }
         if (!this._protocol) {
@@ -255,7 +255,7 @@ Client.ConfigurationBuilder = class ConfigurationBuilder {
     }
 
     _requiredType(val, name, type) {
-        if (!val) throw new Error(`${name} is required`);
+        if (typeof val === 'undefined') throw new Error(`${name} is required`);
         if (typeof val !== type) throw new Error(`Type of ${name} must be ${type}`);
         return val;
     }

--- a/src/main/generic/api/Configuration.js
+++ b/src/main/generic/api/Configuration.js
@@ -255,8 +255,7 @@ Client.ConfigurationBuilder = class ConfigurationBuilder {
     }
 
     _requiredType(val, name, type) {
-        if (typeof val === 'undefined') throw new Error(`${name} is required`);
-        if (typeof val !== type) throw new Error(`Type of ${name} must be ${type}`);
+        if (typeof val !== type) throw new Error(`Type of ${name} must be ${type}, but is ${typeof val}`);
         return val;
     }
 

--- a/src/test/specs/generic/api/ConfigurationBuilder.spec.js
+++ b/src/test/specs/generic/api/ConfigurationBuilder.spec.js
@@ -1,0 +1,16 @@
+describe('Client.ConfigurationBuilder', () => {
+
+    it('can validate a boolean type', () => {
+        const builder = new Client.ConfigurationBuilder();
+        expect(builder._requiredType(true, 'myVariable', 'boolean')).toBe(true);
+        expect(builder._requiredType(false, 'myVariable', 'boolean')).toBe(false);
+    });
+
+    it('can detect mismatching config', () => {
+        const builder = new Client.ConfigurationBuilder();
+        builder.volatile(true);
+        builder.feature(Client.Feature.LOCAL_HISTORY);
+        expect(() => builder.build()).toThrowError('Local history is not available with volatile storage');
+    });
+
+});


### PR DESCRIPTION
The Client API configuration builder has two bugs:

- The check for `volatile` is the wrong way around (e.g. throws error when _not volatile_)
- The `_requiredType` validator rejects _falsy_ variables, making it impossible to check for boolean `false`

I fixed those problems and added tests for them.