### PR TITLE
Fix handling of pending knownTx in Client

### DIFF
--- a/src/main/generic/api/Client.js
+++ b/src/main/generic/api/Client.js
@@ -762,7 +762,7 @@ class Client {
         for (const receipt of receipts.valueIterator()) {
             // Skip known transactions that are already considered confirmed.
             const knownTx = knownTxs.get(receipt.transactionHash);
-            if (knownTx && knownTx.state === Client.TransactionState.CONFIRMED && knownTx.blockHash.equals(receipt.blockHash)) {
+            if (knownTx && knownTx.state === Client.TransactionState.CONFIRMED && receipt.blockHash.equals(knownTx.blockHash)) {
                 continue;
             }
 

--- a/src/main/generic/api/Client.js
+++ b/src/main/generic/api/Client.js
@@ -762,7 +762,7 @@ class Client {
         for (const receipt of receipts.valueIterator()) {
             // Skip known transactions that are already considered confirmed.
             const knownTx = knownTxs.get(receipt.transactionHash);
-            if (knownTx && knownTx.blockHash.equals(receipt.blockHash) && knownTx.state === Client.TransactionState.CONFIRMED) {
+            if (knownTx && knownTx.state === Client.TransactionState.CONFIRMED && knownTx.blockHash.equals(receipt.blockHash)) {
                 continue;
             }
 
@@ -817,7 +817,7 @@ class Client {
                     txs.add(new Client.TransactionDetails(details.transaction, Client.TransactionState.EXPIRED));
                 } else {
                     // Add to mempool.
-                    txs.add(this.sendTransaction(details.transaction));
+                    txs.add(await this.sendTransaction(details.transaction));
                 }
             }
         }


### PR DESCRIPTION
`getTransactionsByAddress()` throws an exception when _pending_ transaction details are passed to it in the `knownTransactionDetails`, because the check for a matching `blockHash` is done for all passed details.

This check then fails with `Cannot read property 'equals' of undefined` for pending transaction details, as they don't have a block hash yet.

Switching the check for the details `state` to run first fixes the problem.