### PR TITLE
Adding path parameter to Nimiq.load()

### DIFF
--- a/dist/types.d.ts
+++ b/dist/types.d.ts
@@ -1,4 +1,4 @@
-export function load(): Promise<void>;
+export function load(path?: string): Promise<void>;
 
 export let _path: string | undefined;
 


### PR DESCRIPTION
`Nimiq.load()` was missing optional `path` parameter.

## Pull request checklist

- [?] All tests pass. Demo project builds and runs.
- [?] I have resolved any merge conflicts.

#### This fixes issue #___.

## What's in this pull request?

Just an extension to the types definitions - shouldn't break anything.
