### PR TITLE
Fix travis' illegal instruction errors

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -26,7 +26,9 @@ install: true
 jobs:
   include:
     - stage: build nimiq
-      env: BUILD=true
+      env:
+        - BUILD=true
+        - PACKAGING=1
       script:
         - npm install -g gulp
         - yarn

--- a/binding.gyp
+++ b/binding.gyp
@@ -1,48 +1,50 @@
 {
-    "targets": [
-        {
-            "target_name": "nimiq_node_native",
-            "sources": [
-                "src/native/argon2.c",
-                "src/native/blake2/blake2b.c",
-                "src/native/core.c",
-                "src/native/encoding.c",
-                "src/native/nimiq_native.c",
-                "src/native/opt.c",
-                "src/native/sha256.c",
-                "src/native/ed25519/collective.c",
-                "src/native/ed25519/fe.c",
-                "src/native/ed25519/ge.c",
-                "src/native/ed25519/keypair.c",
-                "src/native/ed25519/memory.c",
-                "src/native/ed25519/sc.c",
-                "src/native/ed25519/sha512.c",
-                "src/native/ed25519/sign.c",
-                "src/native/ed25519/verify.c",
-                "src/native/nimiq_node.cc"
-            ],
-            "defines": [
-                "ARGON2_NO_THREADS"
-            ],
-            "include_dirs": [
-                "<!(node -e \"require('nan')\")",
-                "src/native"
-            ],
-            "cflags_c": [
-                "-std=c99",
-                "-march=native"
-            ],
-            "xcode_settings": {
-                "OTHER_CFLAGS": [
-                    "-march=native"
-                ]
-            }
-        },
-    ],
     "variables": {
         "packaging": "<!(echo $PACKAGING)"
     },
     "conditions": [
+        ["packaging!=1", {
+            "targets": [
+                {
+                    "target_name": "nimiq_node_native",
+                    "sources": [
+                        "src/native/argon2.c",
+                        "src/native/blake2/blake2b.c",
+                        "src/native/core.c",
+                        "src/native/encoding.c",
+                        "src/native/nimiq_native.c",
+                        "src/native/opt.c",
+                        "src/native/sha256.c",
+                        "src/native/ed25519/collective.c",
+                        "src/native/ed25519/fe.c",
+                        "src/native/ed25519/ge.c",
+                        "src/native/ed25519/keypair.c",
+                        "src/native/ed25519/memory.c",
+                        "src/native/ed25519/sc.c",
+                        "src/native/ed25519/sha512.c",
+                        "src/native/ed25519/sign.c",
+                        "src/native/ed25519/verify.c",
+                        "src/native/nimiq_node.cc"
+                    ],
+                    "defines": [
+                        "ARGON2_NO_THREADS"
+                    ],
+                    "include_dirs": [
+                        "<!(node -e \"require('nan')\")",
+                        "src/native"
+                    ],
+                    "cflags_c": [
+                        "-std=c99",
+                        "-march=native"
+                    ],
+                    "xcode_settings": {
+                        "OTHER_CFLAGS": [
+                            "-march=native"
+                        ]
+                    }
+                },
+            ]
+        }],
         ["packaging==1", {
             "targets": [
                 {

--- a/src/main/platform/nodejs/index.prefix.js
+++ b/src/main/platform/nodejs/index.prefix.js
@@ -39,7 +39,7 @@ function detectAddOn() {
     cpuSupport = cpuSupport || function() {
         try {
             const cpu = cpuid();
-            return ['avx512f', 'avx2', 'sse2'].find(f => cpu.features[f]) || 'compat';
+            return ['avx512f', 'avx2', 'avx', 'sse2'].find(f => cpu.features[f]) || 'compat';
         } catch (e) {
             return 'compat';
         }


### PR DESCRIPTION
It seems that sometimes our Travis builds are being done on a newer CPU than the one where the tests are run in, which leads to the problem that the node.js addon is built optimized with instructions that are no longer available when running the tests (thus failing the tests with an "Illegal instruction" error).

One way to fix the problem is to remove the caching of the addon, but in my benchmarks that would increase the test time by more than 3 minutes and 30 seconds.

A second, more performant, way of fixing the problem is using the same infrastructure we already use for packaging (where instead of building the addon for the CPU where the building is executed, we build several different addons for different CPU optimization levels and then detect the one we are using at runtime, this makes the build process around 30s slower, but the testing doesn't incur in any slowdown).

This PR provides this second method to fix the Travis problem.

Note: because we're also caching `node_modules`, we could run into trouble if we depend on any package that has its own CPU optimized addons, but so far, that hasn't been the case and it's very unlikely that will change in the future.