### PR TITLE
Fix getTransactionReceipt method of the RPC server.

### DIFF
--- a/clients/nodejs/modules/JsonRpcServer.js
+++ b/clients/nodejs/modules/JsonRpcServer.js
@@ -324,7 +324,7 @@ class JsonRpcServer {
         const block = await this._client.getBlock(receipt.blockHash);
         return {
             transactionHash: receipt.transactionHash.toHex(),
-            transactionIndex: block ? block.transactions.findIndex(tx => tx.hash().equals(hash)) : undefined,
+            transactionIndex: block ? block.transactions.findIndex(tx => tx.hash().toHex() === hash) : undefined,
             blockNumber: receipt.blockHeight,
             blockHash: receipt.blockHash.toHex(),
             confirmations: (await this._client.getHeadHeight()) - receipt.blockHeight,


### PR DESCRIPTION
Hexadecimal presentation of the hash should be used to find a transaction.

## Pull request checklist

- [*] All tests pass. Demo project builds and runs.
- [*] I have resolved any merge conflicts.

#### This fixes issue #528.

## What's in this pull request?

> Simple fix of the issue #528
