### PR TITLE
Add hints for WSS and WS missing config options

### DIFF
--- a/clients/nodejs/index.js
+++ b/clients/nodejs/index.js
@@ -16,6 +16,15 @@ if (config.dumb) {
 if ((config.protocol === 'wss' && !(config.host && config.port && config.tls && config.tls.cert && config.tls.key)) ||
     (config.protocol === 'ws' && !(config.host && config.port)) ||
     argv.help) {
+
+    if (!argv.help && config.protocol === 'wss') {
+        console.error('WSS protocol requries host, port, TLS cert and TLS key to be configured!');
+    }
+
+    if (!argv.help && config.protocol === 'ws') {
+        console.error('WS protocol requries host and port to be configured!');
+    }
+
     console.log(
         'Nimiq NodeJS client\n' +
         '\n' +


### PR DESCRIPTION
There recently was a case of a new user trying to configure a node, who had problems figuring out what was required for WSS and WS protocols. The node currently (before this PR) does nothing to help find missing config options, and instead only shows the help page again.

This PR adds an error to the help output explaining what might be missing.