### PR TITLE
Order tx receipts before applying limit argument in Client

### DIFF
--- a/src/main/generic/api/Client.js
+++ b/src/main/generic/api/Client.js
@@ -688,11 +688,7 @@ class Client {
         address = Address.fromAny(address);
 
         const consensus = await this._consensus;
-        const receipts = await consensus.getTransactionReceiptsByAddress(address);
-        // Send receipts are returned first in the resulting array, so we need to order by blockHeight DESC
-        // to have the most recent receipts across both sends and receives first.
-        receipts.sort((a, b) => b.blockHeight - a.blockHeight);
-        return receipts.slice(0, limit);
+        return consensus.getTransactionReceiptsByAddress(address, limit);
     }
 
     /**
@@ -761,7 +757,7 @@ class Client {
 
         // Fetch transaction receipts.
         const receipts = new HashSet((receipt) => receipt.transactionHash.hashCode());
-        if (txs.length < limit) receipts.addAll(await this.getTransactionReceiptsByAddress(address, limit - txs.length));
+        if (txs.length < limit) receipts.addAll(await consensus.getTransactionReceiptsByAddress(address, limit - txs.length));
 
         /** @type {HashMap.<string, HashSet.<Hash>>} */
         const requestProofs = new HashMap();

--- a/src/main/generic/api/Client.js
+++ b/src/main/generic/api/Client.js
@@ -688,7 +688,11 @@ class Client {
         address = Address.fromAny(address);
 
         const consensus = await this._consensus;
-        return consensus.getTransactionReceiptsByAddress(address, limit);
+        const receipts = await consensus.getTransactionReceiptsByAddress(address);
+        // Send receipts are returned first in the resulting array, so we need to order by blockHeight DESC
+        // to have the most recent receipts across both sends and receives first.
+        receipts.sort((a, b) => b.blockHeight - a.blockHeight);
+        return receipts.slice(0, limit);
     }
 
     /**
@@ -757,7 +761,7 @@ class Client {
 
         // Fetch transaction receipts.
         const receipts = new HashSet((receipt) => receipt.transactionHash.hashCode());
-        if (txs.length < limit) receipts.addAll(await consensus.getTransactionReceiptsByAddress(address, limit - txs.length));
+        if (txs.length < limit) receipts.addAll(await this.getTransactionReceiptsByAddress(address, limit - txs.length));
 
         /** @type {HashMap.<string, HashSet.<Hash>>} */
         const requestProofs = new HashMap();

--- a/src/main/generic/consensus/BaseConsensusAgent.js
+++ b/src/main/generic/consensus/BaseConsensusAgent.js
@@ -1427,6 +1427,11 @@ class BaseConsensusAgent extends Observable {
         }
 
         let receipts = msg.receipts;
+        // Receipts of sent transactions are returned first in the receipts array
+        // (see FullChain.getTransactionReceiptsByAddress), so we need to order
+        // by descending blockHeight to have the most recent receipts across both
+        // sent and received transactions first.
+        receipts.sort((a, b) => b.blockHeight - a.blockHeight);
         if (limit !== undefined && limit < receipts.length) receipts = receipts.slice(0, limit);
 
         if (hashes !== undefined) {


### PR DESCRIPTION
**The `limit` argument for transaction receipts and history in the Client is deceptive**

The `GetTransactionReceiptsByAddressMessage` does not support any limit parameter, so it always returns the RECEIPTS_MAX_COUNT of 500. The slicing to the user-defined `limit` is then only done on the client side, which simply takes the first returned tx receipts until the limit. The issue is however, that a full node always returns up to 250 send receipts first (because the peer does not know about the limit), and only in the second half of the array returns the receive receipts.
So when I set my limit to 100, and I have more than 100 sends from that address, I do not get any receive txs, no matter how recent they are in comparison to the sends.

This PR fixes the issue for the Core Client by not using the consensus' built-in `limit` argument, but instead only apply the limit in the Client, _after_ the returned transaction receipts have been sorted by blockHeight descending, to have the most recent receipts first.