### PR TITLE
Add missing Babel module for loader

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -550,6 +550,7 @@ gulp.task('build-loader', function () {
         browserify([], {
             require: [
                 '@babel/runtime-corejs2/core-js/date/now',
+                '@babel/runtime-corejs2/core-js/get-iterator',
                 '@babel/runtime-corejs2/core-js/number/is-integer',
                 '@babel/runtime-corejs2/core-js/number/max-safe-integer',
                 '@babel/runtime-corejs2/core-js/promise',


### PR DESCRIPTION
In v1.5.5, the `nimiq.js` loader fails to run because of an error when the file is interpreted:
```
Uncaught Error: Cannot find module '@babel/runtime-corejs2/core-js/get-iterator'
    at o (babel-runtime.js:1)
    at o (babel-runtime.js:1)
    at WindowDetector.js:86
```
This PR adds the missing module in the Gulp task.