### PR TITLE
Fix browser clients not being detected as WebRTC-ready in Client API

### DIFF
--- a/src/main/generic/api/Configuration.js
+++ b/src/main/generic/api/Configuration.js
@@ -207,7 +207,7 @@ Client.ConfigurationBuilder = class ConfigurationBuilder {
         }
         if (!this._protocol) {
             if (PlatformUtils.supportsWebRTC()) this._protocol = 'rtc';
-            this._protocol = 'dumb';
+            else this._protocol = 'dumb';
         }
         if (!this._reverseProxy) {
             this._reverseProxy = {enabled: false};
@@ -219,7 +219,7 @@ Client.ConfigurationBuilder = class ConfigurationBuilder {
                 networkConfig = new DumbNetworkConfig();
                 break;
             case 'rtc':
-                if (PlatformUtils.supportsWebRTC()) throw new Error('WebRTC not supported on this platform');
+                if (!PlatformUtils.supportsWebRTC()) throw new Error('WebRTC not supported on this platform');
                 networkConfig = new RtcNetworkConfig();
                 break;
             case 'ws':


### PR DESCRIPTION
I noticed that when using the Client API to instantiate a Nimiq client in the browser, no WebRTC peers where ever accepted into the known-addresses pool of the network, but when using legacy `consensus.pico()` instantiation, they were.

Turns out the Client API fails to set the protocol to `rtc` in a browser because of a missing `else` and negation.