### PR TITLE
Typing improvements

### DIFF
--- a/dist/types.d.ts
+++ b/dist/types.d.ts
@@ -550,7 +550,7 @@ export class IteratorUtils {
 
 export class ArrayUtils {
     public static randomElement(arr: any[]): any;
-    public static subarray(uintarr: Uint8Array, begin: number, end: number): Uint8Array;
+    public static subarray(uintarr: Uint8Array, begin?: number, end?: number): Uint8Array;
     public static k_combinations(list: any[], k: number): Generator;
 }
 
@@ -766,7 +766,7 @@ export class SerialBuffer extends Uint8Array {
     public readPos: number;
     public writePos: number;
     constructor(bufferOrArrayOrLength: any)
-    public subarray(start: number, end: number): Uint8Array;
+    public subarray(start?: number, end?: number): Uint8Array;
     public reset(): void;
     public read(length: number): Uint8Array;
     public write(array: any): void;
@@ -1039,7 +1039,7 @@ export class Hash extends Serializable {
     public algorithm: Hash.Algorithm;
     constructor(arg?: Uint8Array, algorithm?: Hash.Algorithm);
     public serialize(buf?: SerialBuffer): SerialBuffer;
-    public subarray(begin: number, end: number): Uint8Array;
+    public subarray(begin?: number, end?: number): Uint8Array;
     public toPlain(): string;
     public equals(o: Serializable): boolean;
 }
@@ -1266,7 +1266,7 @@ export class Address extends Serializable {
     public serializedSize: number;
     constructor(arg: Uint8Array);
     public serialize(buf?: SerialBuffer): SerialBuffer;
-    public subarray(begin: number, end: number): Uint8Array;
+    public subarray(begin?: number, end?: number): Uint8Array;
     public equals(o: Address): boolean;
     public toPlain(): string;
     public toUserFriendlyAddress(withSpaces?: boolean): string;
@@ -3395,7 +3395,7 @@ export class PeerId extends Serializable {
     public serializedSize: number;
     constructor(arg: Uint8Array);
     public serialize(buf?: SerialBuffer): SerialBuffer;
-    public subarray(begin: number, end: number): Uint8Array;
+    public subarray(begin?: number, end?: number): Uint8Array;
     public equals(o: any): boolean;
     public toString(): string;
 }

--- a/dist/types.d.ts
+++ b/dist/types.d.ts
@@ -727,7 +727,7 @@ export class Assert {
 export class CryptoUtils {
     public static SHA512_BLOCK_SIZE: 128;
     public static computeHmacSha512(key: Uint8Array, data: Uint8Array): Uint8Array;
-    public static computePBKDF2sha512(password: Uint8Array, salt: Uint8Array, iterations: number, derivedKeyLength: number): Uint8Array;
+    public static computePBKDF2sha512(password: Uint8Array, salt: Uint8Array, iterations: number, derivedKeyLength: number): SerialBuffer;
     public static otpKdfLegacy(message: Uint8Array, key: Uint8Array, salt: Uint8Array, iterations: number): Promise<Uint8Array>;
     public static otpKdf(message: Uint8Array, key: Uint8Array, salt: Uint8Array, iterations: number): Promise<Uint8Array>;
 }
@@ -1234,7 +1234,7 @@ export class MnemonicUtils {
     public static entropyToLegacyMnemonic(entropy: string | ArrayBuffer | Uint8Array | Entropy, wordlist?: string[]): string[];
     public static mnemonicToEntropy(mnemonic: string | string[], wordlist?: string[]): Entropy;
     public static legacyMnemonicToEntropy(mnemonic: string | string[], wordlist?: string[]): Entropy;
-    public static mnemonicToSeed(mnemonic: string | string[], password?: string): Uint8Array;
+    public static mnemonicToSeed(mnemonic: string | string[], password?: string): SerialBuffer;
     public static mnemonicToExtendedPrivateKey(mnemonic: string | string[], password?: string): ExtendedPrivateKey;
     public static isCollidingChecksum(entropy: Entropy): boolean;
     public static getMnemonicType(mnemonic: string | string[], wordlist?: string[]): MnemonicUtils.MnemonicType;

--- a/src/main/generic/consensus/base/account/Address.js
+++ b/src/main/generic/consensus/base/account/Address.js
@@ -44,6 +44,11 @@ class Address extends Serializable {
         return buf;
     }
 
+    /**
+     * @param {number} [begin]
+     * @param {number} [end]
+     * @returns {Uint8Array}
+     */
     subarray(begin, end) {
         return this._obj.subarray(begin, end);
     }

--- a/src/main/generic/consensus/base/primitive/Hash.js
+++ b/src/main/generic/consensus/base/primitive/Hash.js
@@ -103,8 +103,8 @@ class Hash extends Serializable {
     }
 
     /**
-     * @param {number} begin
-     * @param {number} end
+     * @param {number} [begin]
+     * @param {number} [end]
      * @returns {Uint8Array}
      */
     subarray(begin, end) {

--- a/src/main/generic/network/address/PeerId.js
+++ b/src/main/generic/network/address/PeerId.js
@@ -36,6 +36,11 @@ class PeerId extends Serializable {
         return buf;
     }
 
+    /**
+     * @param {number} [begin]
+     * @param {number} [end]
+     * @returns {Uint8Array}
+     */
     subarray(begin, end) {
         return this._obj.subarray(begin, end);
     }

--- a/src/main/generic/utils/array/ArrayUtils.js
+++ b/src/main/generic/utils/array/ArrayUtils.js
@@ -10,8 +10,8 @@ class ArrayUtils {
 
     /**
      * @param {Uint8Array} uintarr
-     * @param {number} begin
-     * @param {number} end
+     * @param {number} [begin]
+     * @param {number} [end]
      * @return {Uint8Array}
      */
     static subarray(uintarr, begin, end) {

--- a/src/main/generic/utils/buffer/SerialBuffer.js
+++ b/src/main/generic/utils/buffer/SerialBuffer.js
@@ -10,8 +10,8 @@ class SerialBuffer extends Uint8Array {
     }
 
     /**
-     * @param {number} start
-     * @param {number} end
+     * @param {number} [start]
+     * @param {number} [end]
      * @return {Uint8Array}
      */
     subarray(start, end) {

--- a/src/main/generic/utils/crypto/CryptoUtils.js
+++ b/src/main/generic/utils/crypto/CryptoUtils.js
@@ -26,7 +26,7 @@ class CryptoUtils {
      * @param {Uint8Array} salt
      * @param {number} iterations
      * @param {number} derivedKeyLength
-     * @return {Uint8Array}
+     * @return {SerialBuffer}
      */
     static computePBKDF2sha512(password, salt, iterations, derivedKeyLength) {
         // Following https://www.ietf.org/rfc/rfc2898.txt

--- a/src/main/generic/utils/mnemonic/MnemonicUtils.js
+++ b/src/main/generic/utils/mnemonic/MnemonicUtils.js
@@ -187,7 +187,7 @@ class MnemonicUtils {
     /**
      * @param {string|Array.<string>} mnemonic
      * @param {string} [password]
-     * @returns {Uint8Array}
+     * @returns {SerialBuffer}
      */
     static mnemonicToSeed(mnemonic, password) {
         if (Array.isArray(mnemonic)) mnemonic = mnemonic.join(' ');


### PR DESCRIPTION
Arguments to all `subarray()` methods in the source code are _actually_ optional. They are both optional in the native `Uint8Array`, and also in the `ArrayUtils` implementation.

Additionally, this fixes the return value of the `CryptoUtils.computePBKDF2sha512()` method, which actually returns a `SerialBuffer`. This is important when working with `MnemonicUtils.mnemonicToSeed()`, as that uses the first method internally.