### PR TITLE
Fire 'removed' event when removing a peer from PeerAddressBook

### DIFF
--- a/src/main/generic/network/address/PeerAddressBook.js
+++ b/src/main/generic/network/address/PeerAddressBook.js
@@ -666,6 +666,7 @@ class PeerAddressBook extends Observable {
 
         // Delete the address.
         this._store.remove(peerAddress);
+        this.fire('removed', peerAddress, this);
     }
 
     /**


### PR DESCRIPTION
This PR adds the firing of a `removed` event to the `PeerAddressBook`, which gets fired when - surprise - a peer is removed.

We will use this in the network map of the new Wallet. This event significantly reduces the number of data to be requested from the Nimiq node and to be processed, as instead of the current approach of fetching the complete set of known peers periodically, we only process the delta whenever the `added` or `removed` event is fired.

[skip ci]