### PR TITLE
Replace Uint8Array.from with new Uint8Array

### DIFF
--- a/src/main/generic/utils/buffer/BufferUtils.js
+++ b/src/main/generic/utils/buffer/BufferUtils.js
@@ -113,7 +113,7 @@ class BufferUtils {
      * @return {SerialBuffer}
      */
     static fromBase64(base64, length) {
-        const arr = Uint8Array.from(atob(base64), c => c.charCodeAt(0));
+        const arr = new Uint8Array(atob(base64).split('').map(c => c.charCodeAt(0)));
         if (length !== undefined && arr.length !== length) throw new Error('Decoded length does not match expected length');
         return new SerialBuffer(arr);
     }
@@ -231,7 +231,7 @@ class BufferUtils {
     static fromHex(hex, length) {
         hex = hex.trim();
         if (!StringUtils.isHexBytes(hex, length)) throw new Error('String is not an hex string (of matching length)');
-        return new SerialBuffer(Uint8Array.from(hex.match(/.{2}/g) || [], byte => parseInt(byte, 16)));
+        return new SerialBuffer(new Uint8Array((hex.match(/.{2}/g) || []).map(byte => parseInt(byte, 16))));
     }
 
     /**
@@ -410,7 +410,7 @@ class BufferUtils {
         } else if (arrayLike.buffer instanceof ArrayBuffer) {
             return new Uint8Array(arrayLike.buffer);
         } else {
-            return Uint8Array.from(arrayLike);
+            return new Uint8Array(arrayLike);
         }
     }
 }

--- a/src/main/generic/utils/buffer/BufferUtils.js
+++ b/src/main/generic/utils/buffer/BufferUtils.js
@@ -1,6 +1,6 @@
 class BufferUtils {
     /**
-     * @param {*} buffer
+     * @param {Uint8Array} buffer
      * @return {string}
      */
     static toAscii(buffer) {
@@ -90,7 +90,7 @@ class BufferUtils {
     }
 
     /**
-     * @param {*} buffer
+     * @param {Uint8Array} buffer
      * @return {string}
      */
     static toBase64(buffer) {
@@ -119,7 +119,7 @@ class BufferUtils {
     }
 
     /**
-     * @param {*} buffer
+     * @param {Uint8Array} buffer
      * @return {string}
      */
     static toBase64Url(buffer) {
@@ -210,7 +210,7 @@ class BufferUtils {
     }
 
     /**
-     * @param {*} buffer
+     * @param {Uint8Array} buffer
      * @return {string}
      */
     static toHex(buffer) {
@@ -235,7 +235,7 @@ class BufferUtils {
     }
 
     /**
-     * @param {*} bytes
+     * @param {Uint8Array} buffer
      * @return {string}
      */
     static toBinary(buffer) {
@@ -355,14 +355,14 @@ class BufferUtils {
     }
 
     /**
-     * @param {*} a
-     * @param {*} b
+     * @param {TypedArray} a
+     * @param {TypedArray} b
      * @return {boolean}
      */
     static equals(a, b) {
-        if ((a.byteLength || a.length) !== (b.byteLength || b.length)) return false;
         const viewA = BufferUtils._toUint8View(a);
         const viewB = BufferUtils._toUint8View(b);
+        if (viewA.length !== viewB.length) return false;
         for (let i = 0; i < viewA.length; i++) {
             if (viewA[i] !== viewB[i]) return false;
         }
@@ -370,8 +370,8 @@ class BufferUtils {
     }
 
     /**
-     * @param {*} a
-     * @param {*} b
+     * @param {TypedArray} a
+     * @param {TypedArray} b
      * @return {number} -1 if a is smaller than b, 1 if a is larger than b, 0 if a equals b.
      */
     static compare(a, b) {
@@ -398,19 +398,19 @@ class BufferUtils {
     }
 
     /**
-     * @param {*} arrayLike
+     * @param {TypedArray|ArrayBuffer} arrayLike
      * @return {Uint8Array}
      * @private
      */
     static _toUint8View(arrayLike) {
         if (arrayLike instanceof Uint8Array) {
             return arrayLike;
-        } if (arrayLike instanceof ArrayBuffer) {
+        } else if (arrayLike instanceof ArrayBuffer) {
             return new Uint8Array(arrayLike);
         } else if (arrayLike.buffer instanceof ArrayBuffer) {
             return new Uint8Array(arrayLike.buffer);
         } else {
-            return new Uint8Array(arrayLike);
+            throw new Error('TypedArray or ArrayBuffer required');
         }
     }
 }

--- a/src/test/specs/generic/consensus/Genesis.spec.js
+++ b/src/test/specs/generic/consensus/Genesis.spec.js
@@ -22,7 +22,7 @@ describe('Genesis', () => {
             for (const networkId in GenesisConfig.CONFIGS) {
                 const accounts = await Accounts.createVolatile();
                 await accounts.initialize(GenesisConfig.CONFIGS[networkId].GENESIS_BLOCK, GenesisConfig.CONFIGS[networkId].GENESIS_ACCOUNTS);
-                expect(BufferUtils.equals(await accounts.hash(), GenesisConfig.CONFIGS[networkId].GENESIS_BLOCK.accountsHash)).toBeTruthy(`networkId ${networkId}`);
+                expect((await accounts.hash()).equals(GenesisConfig.CONFIGS[networkId].GENESIS_BLOCK.accountsHash)).toBeTruthy(`networkId ${networkId}`);
             }
         })().then(done, done.fail);
     });

--- a/src/test/specs/generic/consensus/base/block/Block.spec.js
+++ b/src/test/specs/generic/consensus/base/block/Block.spec.js
@@ -76,7 +76,7 @@ describe('Block', () => {
         const block2 = Block.unserialize(block.serialize());
 
         expect(block2.serializedSize).toBe(size);
-        expect(BufferUtils.equals(block, block2)).toBe(true);
+        expect(block.equals(block2)).toBe(true);
     });
 
     it('is self plain', () => {

--- a/src/test/specs/generic/consensus/base/block/BlockBody.spec.js
+++ b/src/test/specs/generic/consensus/base/block/BlockBody.spec.js
@@ -19,7 +19,7 @@ describe('BlockBody', () => {
         const blockBody2 = BlockBody.unserialize(blockBody1.serialize());
         expect(blockBody1.equals(blockBody2)).toBe(true);
         expect(BufferUtils.equals(blockBody1.serialize(), blockBody2.serialize())).toBe(true);
-        expect(BufferUtils.equals(blockBody1.hash(), blockBody2.hash())).toBe(true);
+        expect(blockBody1.hash().equals(blockBody2.hash())).toBe(true);
         expect(BufferUtils.equals(blockBody1.extraData, blockBody2.extraData)).toBe(true);
     });
 

--- a/src/test/specs/generic/network/message/VersionMessage.spec.js
+++ b/src/test/specs/generic/network/message/VersionMessage.spec.js
@@ -22,7 +22,6 @@ describe('VersionMessage', () => {
         expect(msg2.genesisHash.equals(msg1.genesisHash)).toBe(true);
         expect(msg2.headHash.equals(msg1.headHash)).toBe(true);
         expect(BufferUtils.equals(msg2.challengeNonce, msg1.challengeNonce)).toBe(true);
-        expect(msg2.userAgent !== msg1.userAgent).toBe(true);
     });
 
     it('is serializable and unserializable (with user-agent)', () => {
@@ -34,7 +33,7 @@ describe('VersionMessage', () => {
         expect(msg2.genesisHash.equals(msg1.genesisHash)).toBe(true);
         expect(msg2.headHash.equals(msg1.headHash)).toBe(true);
         expect(BufferUtils.equals(msg2.challengeNonce, msg1.challengeNonce)).toBe(true);
-        expect(BufferUtils.equals(msg2.userAgent, msg1.userAgent)).toBe(true);
+        expect(msg2.userAgent === msg1.userAgent).toBe(true);
     });
 
     it('must have well defined arguments', () => {

--- a/src/test/specs/generic/utils/buffer/BufferUtils.spec.js
+++ b/src/test/specs/generic/utils/buffer/BufferUtils.spec.js
@@ -152,9 +152,9 @@ describe('BufferUtils', () => {
         const buffer3 = BufferUtils.fromAscii('test false');
         const buffer4 = new Uint16Array(buffer3.buffer);
         const buffer5 = BufferUtils.fromAscii('tess');
-        const buffer6 = [116, 101, 115, 115];
+        const buffer6 = new Uint8Array([116, 101, 115, 115]);
         const buffer7 = BufferUtils.fromAscii('uest');
-        const buffer8 = [];
+        const buffer8 = new Uint8Array(0);
         const buffer9 = BufferUtils.fromHex('e65e39616662f2c16d62dc08915e5a1d104619db8c2b9cf9b389f96c8dce9837');
         const buffer10 = BufferUtils.fromHex('e65e39616662f2c16d62dc08915e5a1d104619db9c2b9cf9b389f96c8dce9837');
 


### PR DESCRIPTION
- [x] All tests pass. Demo project builds and runs.
- [x] I have resolved any merge conflicts.

## What's in this pull request?

In the voting app, we ran into an issue on iOS Safari, which threw an error of
`TypedArray.from requires its this argument subclass a TypedArray constructor` when trying to initialise a `GenesisConfig`. The stack trace traces it back to `BufferUtils.fromHex()`.

Eventually, the issue was that [an external library that was bundled with the app](https://github.com/zloirock/core-js/blob/master/packages/core-js/modules/es.typed-array.uint8-array.js) overwrote the browser's native `Uint8Array` constructor with a shim, which triggered the error in Safari.

While we will fix it in the voting app by removing this shim, we can also make the Nimiq Core library more resilient to this problem by simply _not_ using `Uint8Array.from()`, but using `new UintArray()` instead. This PR does exactly that. It does the byte-mapping _before_ handing it to the Uint8Array constructor, [avoiding the problem](https://github.com/zloirock/core-js/issues/285#issuecomment-291864221).