### PR TITLE
Add LOST as a possible Client.ConsensusState

### DIFF
--- a/src/main/generic/api/Client.js
+++ b/src/main/generic/api/Client.js
@@ -972,7 +972,11 @@ Client.ConsensusState = {
     /**
      * The client reached consensus with its peers
      */
-    ESTABLISHED: 'established'
+    ESTABLISHED: 'established',
+    /**
+     * The client has no connection to peers and lost consensus
+     */
+    LOST: 'lost',
 };
 
 Class.register(Client);


### PR DESCRIPTION
The `LOST` consensus state, while possible, was missing from the `Client.ConsensusState` enum.