### PR TITLE
Include netAddress in plain Client.AddressInfo

### DIFF
--- a/dist/types.d.ts
+++ b/dist/types.d.ts
@@ -153,11 +153,16 @@ declare class ClientBasicAddress {
     public peerAddress: PeerAddress;
     public peerId: PeerId;
     public services: string[];
+    public netAddress: NetAddress | null;
     constructor(address: PeerAddress);
     public toPlain(): {
         peerAddress: string,
         peerId: string,
         services: string[],
+        netAddress: {
+            ip: Uint8Array,
+            reliable: boolean,
+        } | null,
     };
 }
 
@@ -3402,7 +3407,7 @@ export class PeerAddress {
     public protocol: number;
     public services: number;
     public timestamp: number;
-    public netAddress: NetAddress;
+    public netAddress: NetAddress | null;
     public publicKey: PublicKey;
     public peerId: PeerId;
     public distance: number;

--- a/src/main/generic/api/NetworkClient.js
+++ b/src/main/generic/api/NetworkClient.js
@@ -165,12 +165,21 @@ Client.BasicAddress = class BasicAddress {
         return Services.toNameArray(Services.legacyProvideToCurrent(this._address.services));
     }
 
+    /** @type {NetAddress} */
+    get netAddress() {
+        return this._address.netAddress;
+    }
+
     /** @type {object} */
     toPlain() {
         return {
             peerAddress: this.peerAddress.toString(),
             peerId: this.peerId.toString(),
-            services: this.services
+            services: this.services,
+            netAddress: this.netAddress ? {
+                ip: this.netAddress.ip,
+                reliable: this.netAddress.reliable,
+            } : null,
         };
     }
 };


### PR DESCRIPTION
To be able to locate RTC clients on a map, the `AddressInfo`s that get returned by `Client.network.getAddresses()` need to include their IP address, not just their `peerId` (which is just a random HEX string).