### PR TITLE
Fix wrong variable name in HTLC.dataToPlain()

### DIFF
--- a/src/main/generic/consensus/base/account/HashedTimeLockedContract.js
+++ b/src/main/generic/consensus/base/account/HashedTimeLockedContract.js
@@ -369,7 +369,7 @@ class HashedTimeLockedContract extends Contract {
      */
     static dataToPlain(data) {
         try {
-            const buf = new SerialBuffer(proof);
+            const buf = new SerialBuffer(data);
 
             const sender = Address.unserialize(buf);
             const recipient = Address.unserialize(buf);


### PR DESCRIPTION
It seems `proof` was a copy-and-paste error from the `proofToPlain` method.