### PR TITLE
Replace magic utf-8 characters with unicode encoding

### DIFF
--- a/src/main/generic/utils/buffer/BufferUtils.js
+++ b/src/main/generic/utils/buffer/BufferUtils.js
@@ -39,8 +39,14 @@ class BufferUtils {
         }
         const uint8View = BufferUtils._toUint8View(buffer);
         return BufferUtils._ISO_8859_15_DECODER.decode(uint8View)
-            .replace('€', '¤').replace('Š', '¦').replace('š', '¨').replace('Ž', '´')
-            .replace('ž', '¸').replace('Œ', '¼').replace('œ', '½').replace('Ÿ', '¾');
+            .replace(/\u20ac/g, '\u00a4')  // € => ¤
+            .replace(/\u0160/g, '\u00a6')  // Š => ¦
+            .replace(/\u0161/g, '\u00a8')  // š => ¨
+            .replace(/\u017d/g, '\u00b4')  // Ž => ´
+            .replace(/\u017e/g, '\u00b8')  // ž => ¸
+            .replace(/\u0152/g, '\u00bc')  // Œ => ¼
+            .replace(/\u0153/g, '\u00bd')  // œ => ½
+            .replace(/\u0178/g, '\u00be'); // Ÿ => ¾
     }
 
     static _tripletToBase64(num) {


### PR DESCRIPTION
When the server hosting the Nimiq lib for browsers does not set the character encoding of the file in the `Content-Type` header, the Nimiq library is interpreted as `ISO-8859-1` (as per HTTP standard) instead of `UTF-8` (which it is meant to be). This leads to magic utf-8 characters in the `BufferUtils._codePointTextDecoder` method (used by `BufferUtils.toBase64`)  to get mangled, and leads to the method returning the wrong base64 string (as the wrong bytes are `replace`d).

To avoid this problem, this PR replaces the magic utf-8 characters with their equivalent HEX representation.

(The alternative is to avoid using base64 in the Client API: https://github.com/nimiq/core-js/compare/master...soeren/client-hex-hash)