### PR TITLE
Add test for HTLC conversion to and from plain format

### DIFF
--- a/src/test/specs/generic/consensus/base/account/HashedTimeLockedContract.spec.js
+++ b/src/test/specs/generic/consensus/base/account/HashedTimeLockedContract.spec.js
@@ -531,4 +531,27 @@ describe('HashedTimeLockedContract', () => {
         expect(plain.creatorPublicKey).toEqual(keyPair.publicKey.toHex());
         expect(plain.creatorPathLength).toEqual(0);
     });
+
+    fit('can convert itself to and from plain', () => {
+        const keyPair1 = KeyPair.generate();
+        const addr1 = keyPair1.publicKey.toAddress();
+        const keyPair2 = KeyPair.generate();
+        const addr2 = keyPair2.publicKey.toAddress();
+
+        const hashRoot = Hash.sha256(Hash.NULL.array);
+
+        const htlc = new HashedTimeLockedContract(1e5, addr1, addr2, hashRoot, 1, 1000);
+        const plain = htlc.toPlain();
+        const revived = HashedTimeLockedContract.fromPlain(plain);
+
+        expect(revived.sender.equals(addr1)).toBe(true);
+        expect(revived.recipient.equals(addr2)).toBe(true);
+        expect(revived.balance).toBe(1e5);
+        expect(revived.hashRoot.equals(hashRoot)).toBe(true); // fails
+        expect(revived.hashRoot.algorithm).toBe(Hash.Algorithm.SHA256); // fails
+        expect(revived.hashCount).toBe(1);
+        expect(revived.totalAmount).toBe(1e5);
+
+        expect(htlc.equals(revived)).toBe(true); // fails
+    });
 });


### PR DESCRIPTION
This PR adds a failing test which shows that HTLCs cannot recreate themselves from the `plain` format.

This is due to the hash algorithm not getting picked up during `fromPlain` and thus the hashRoot `Hash` getting re-initialized with the default Blake2b, although the original HTLC specified another hash algorithm.