### PR TITLE
Fix type errors in types.d.ts definition file (and in code by extension)

### DIFF
--- a/dist/types.d.ts
+++ b/dist/types.d.ts
@@ -902,10 +902,10 @@ export class NumberUtils {
     public static UINT16_MAX: 65535;
     public static UINT32_MAX: 4294967295;
     public static UINT64_MAX: number;
-    public static isUint8(val: number): boolean;
-    public static isUint16(val: number): boolean;
-    public static isUint32(val: number): boolean;
-    public static isUint64(val: number): boolean;
+    public static isUint8(val: unknown): boolean;
+    public static isUint16(val: unknown): boolean;
+    public static isUint32(val: unknown): boolean;
+    public static isUint64(val: unknown): boolean;
     public static randomUint32(): number;
     public static randomUint64(): number;
     public static fromBinary(bin: string): number;

--- a/dist/types.d.ts
+++ b/dist/types.d.ts
@@ -153,7 +153,7 @@ declare class ClientBasicAddress {
     public peerAddress: PeerAddress;
     public peerId: PeerId;
     public services: string[];
-    public netAddress: NetAddress | null;
+    public netAddress: NetAddress;
     constructor(address: PeerAddress);
     public toPlain(): {
         peerAddress: string,
@@ -175,6 +175,10 @@ declare class ClientAddressInfo extends ClientBasicAddress {
         peerAddress: string,
         peerId: string,
         services: string[],
+        netAddress: {
+            ip: Uint8Array,
+            reliable: boolean,
+        } | null,
         banned: boolean,
         connected: boolean,
     };
@@ -182,7 +186,6 @@ declare class ClientAddressInfo extends ClientBasicAddress {
 
 declare class ClientPeerInfo extends ClientBasicAddress {
     public connectionSince: number;
-    public netAddress: NetAddress;
     public bytesReceived: number;
     public bytesSent: number;
     public latency: number;
@@ -196,8 +199,11 @@ declare class ClientPeerInfo extends ClientBasicAddress {
         peerAddress: string,
         peerId: string,
         services: string[],
+        netAddress: {
+            ip: Uint8Array,
+            reliable: boolean,
+        } | null,
         connectionSince: number,
-        netAddress: string,
         bytesReceived: number,
         bytesSent: number,
         latency: number,

--- a/dist/types.d.ts
+++ b/dist/types.d.ts
@@ -23,7 +23,7 @@ export class Client {
     public static MempoolStatistics: typeof ClientMempoolStatistics;
     public static Network: typeof ClientNetwork;
     public static BasicAddress: typeof ClientBasicAddress;
-    public static AddressInfo:typeof  ClientAddressInfo;
+    public static AddressInfo: typeof ClientAddressInfo;
     public static PeerInfo: typeof ClientPeerInfo;
     public static NetworkStatistics: typeof ClientNetworkStatistics;
     public static TransactionDetails: typeof ClientTransactionDetails;
@@ -48,6 +48,7 @@ export class Client {
     };
     public network: Client.Network;
     public mempool: Client.Mempool;
+    public _consensusState: Client.ConsensusState;
     constructor(config: Client.Configuration | object, consensus?: Promise<BaseConsensus>);
     public getHeadHash(): Promise<Hash>;
     public getHeadHeight(): Promise<number>;
@@ -62,7 +63,7 @@ export class Client {
     public getTransactionReceipt(hash: Hash | string): Promise<TransactionReceipt | undefined>;
     public getTransactionReceiptsByAddress(address: Address | string, limit?: number): Promise<TransactionReceipt[]>;
     public getTransactionReceiptsByHashes(hashes: Array<Hash | string>): Promise<TransactionReceipt[]>;
-    public getTransactionsByAddress(address: Address | string, sinceBlockHeight?: number, knownTransactionDetails?: Client.TransactionDetails[] | ReturnType<Client.TransactionDetails["toPlain"]>[], limit?: number): Promise<Client.TransactionDetails[]>;
+    public getTransactionsByAddress(address: Address | string, sinceBlockHeight?: number, knownTransactionDetails?: Client.TransactionDetails[] | Array<ReturnType<Client.TransactionDetails['toPlain']>>, limit?: number): Promise<Client.TransactionDetails[]>;
     public sendTransaction(tx: Transaction | object | string): Promise<Client.TransactionDetails>;
     public addBlockListener(listener: BlockListener): Promise<Handle>;
     public addConsensusChangedListener(listener: ConsensusChangedListener): Promise<Handle>;
@@ -70,7 +71,6 @@ export class Client {
     public addTransactionListener(listener: TransactionListener, addresses: Array<Address | string>): Promise<Handle>;
     public removeListener(handle: Handle): Promise<void>;
     public waitForConsensusEstablished(): Promise<void>;
-    public _consensusState: Client.ConsensusState;
 }
 
 export namespace Client {

--- a/dist/types.d.ts
+++ b/dist/types.d.ts
@@ -153,7 +153,7 @@ declare class ClientBasicAddress {
     public peerAddress: PeerAddress;
     public peerId: PeerId;
     public services: string[];
-    public netAddress: NetAddress;
+    public netAddress: NetAddress | null;
     constructor(address: PeerAddress);
     public toPlain(): {
         peerAddress: string,

--- a/src/main/generic/api/NetworkClient.js
+++ b/src/main/generic/api/NetworkClient.js
@@ -176,7 +176,7 @@ Client.BasicAddress = class BasicAddress {
             peerAddress: this.peerAddress.toString(),
             peerId: this.peerId.toString(),
             services: this.services,
-            netAddress: this.netAddress ? {
+            netAddress: this.netAddress.ip ? {
                 ip: this.netAddress.ip,
                 reliable: this.netAddress.reliable,
             } : null,
@@ -292,7 +292,6 @@ Client.PeerInfo = class PeerInfo extends Client.BasicAddress {
     toPlain() {
         const plain = super.toPlain();
         plain.connectionSince = this.connectionSince;
-        plain.netAddress = this.netAddress.toString();
         plain.bytesReceived = this.bytesReceived;
         plain.bytesSent = this.bytesSent;
         plain.latency = this.latency;

--- a/src/main/generic/api/NetworkClient.js
+++ b/src/main/generic/api/NetworkClient.js
@@ -165,7 +165,7 @@ Client.BasicAddress = class BasicAddress {
         return Services.toNameArray(Services.legacyProvideToCurrent(this._address.services));
     }
 
-    /** @type {NetAddress} */
+    /** @type {NetAddress | null} */
     get netAddress() {
         return this._address.netAddress;
     }
@@ -176,7 +176,7 @@ Client.BasicAddress = class BasicAddress {
             peerAddress: this.peerAddress.toString(),
             peerId: this.peerId.toString(),
             services: this.services,
-            netAddress: this.netAddress.ip ? {
+            netAddress: this.netAddress ? {
                 ip: this.netAddress.ip,
                 reliable: this.netAddress.reliable,
             } : null,

--- a/src/main/generic/network/address/PeerAddress.js
+++ b/src/main/generic/network/address/PeerAddress.js
@@ -161,7 +161,7 @@ class PeerAddress {
         return this._timestamp;
     }
 
-    /** @type {NetAddress} */
+    /** @type {NetAddress | null} */
     get netAddress() {
         return this._netAddress.isPseudo() ? null : this._netAddress;
     }

--- a/src/main/generic/utils/number/NumberUtils.js
+++ b/src/main/generic/utils/number/NumberUtils.js
@@ -1,6 +1,6 @@
 class NumberUtils {
     /**
-     * @param {number} val
+     * @param {unknown} val
      * @return {boolean}
      */
     static isUint8(val) {
@@ -9,7 +9,7 @@ class NumberUtils {
     }
 
     /**
-     * @param {number} val
+     * @param {unknown} val
      * @return {boolean}
      */
     static isUint16(val) {
@@ -18,7 +18,7 @@ class NumberUtils {
     }
 
     /**
-     * @param {number} val
+     * @param {unknown} val
      * @return {boolean}
      */
     static isUint32(val) {
@@ -27,7 +27,7 @@ class NumberUtils {
     }
 
     /**
-     * @param {number} val
+     * @param {unknown} val
      * @return {boolean}
      */
     static isUint64(val) {


### PR DESCRIPTION
The type definitions were failing the Typescript compiler because of a broken inheritance type chain in the `NetworkClient` (`Client.Network`). This error was introduced (by me) in #555 which was recently released as v1.5.7. Sorry... :disappointed: 

Basically I overlooked that `Client.PeerInfo` extends `Client.BasicAddress` and thus inherits the parent's `toPlain()` contents, especially the plain `netAddress` object added in #555. However, the child then overwrote this property on the plain object with a _stringified_ `netAddress`. The typing of this string was in the type definitions, clashing with the parent's definition of it being an object instead of a string.

This PR fixes this issue (also in code) by removing the stringified `netAddress` from `Client.PeerInfo`'s `toPlain()` output, and has thus no significant effects for the library.

This PR also fixes the logic to detect if a `netAddress` is present, as the class property `.netAddress` is always defined, as it falls back to `NetAddress.UNSPECIFIED`. This, however, then has an `.ip` of `null`, enabling the proper check.

This PR also fixes some linter errors found when running `npm run lint-types` in this repo.