### PR TITLE
Add MerkleTree to offline build

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -257,6 +257,7 @@ const sources = {
         './src/main/generic/utils/crc/CRC8.js',
         './src/main/generic/utils/number/BigNumber.js',
         './src/main/generic/utils/number/NumberUtils.js',
+        './src/main/generic/utils/merkle/MerkleTree.js',
         './src/main/generic/utils/merkle/MerklePath.js',
         './src/main/generic/utils/mnemonic/MnemonicUtils.js',
         './src/main/generic/utils/string/StringUtils.js',


### PR DESCRIPTION
## Pull request checklist

- [X] All tests pass. Demo project builds and runs.
- [X] I have resolved any merge conflicts.

## What's in this pull request?

This PR adds `MerkleTree` to the offline build.
MerkleTree._hash is used in MerklePath which is part of the offline bundle. MerklePath in turn is used in SignatureProof.