### PR TITLE
Fix issue 603

### DIFF
--- a/doc/linux-packaging.md
+++ b/doc/linux-packaging.md
@@ -7,19 +7,21 @@ Make sure you can build the `node.js` client from source code (i.e. you can succ
 #### Debian/Ubuntu (deb package format)
 
 1. Make sure you have `dpkg`, `jq` and `fakeroot` installed (otherwise, install them with `apt`).
-2. Run `PACKAGING=1 yarn`.
-3. Run `PACKAGING=1 yarn build`.
-4. Then run `yarn run build-deb`.
-5. The deb package will be located in the `dist/` directory.
+2. Run `yarn`.
+3. Run `yarn build`.
+4. Run `PACKAGING=1 yarn --production`.
+5. Then run `./packaging/build-package.sh deb`.
+6. The deb package will be located in the `dist/` directory.
 
 Note: creating deb packages only has been tested extensively on Ubuntu and Debian.
 
 #### Fedora/CentOS/RHEL (RPM package format)
 
 1. Make sure you have `rpm-build` installed (otherwise, install it with `yum` or `dnf`).
-2. Run `PACKAGING=1 yarn`
-3. Run `PACKAGING=1 yarn build`.
-4. Then run `yarn run build-rpm`.
-5. The RPM package will be located in the `dist/` directory.
+2. Run `yarn`
+3. Run `yarn build`.
+4. Run `PACKAGING=1 yarn --production`.
+5. Then run `./packaging/build-package.sh rpm`.
+6. The RPM package will be located in the `dist/` directory.
 
 Note: creating RPM packages only has been tested extensively on Fedora.

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -621,25 +621,6 @@ gulp.task('run-build-node-istanbul', function () {
         .pipe(gulp.dest('dist'));
 });
 
-const RELEASE_SOURCES = [
-    'dist/VERSION',
-    process.execPath
-];
-
-const RELEASE_LIB = [
-    'dist/node.*',
-    'dist/worker-*',
-    'dist/web.*'
-];
-
-const RELEASE_ADDONS = [
-    'build/Release/nimiq_node_compat.node',
-    'build/Release/nimiq_node_sse2.node',
-    'build/Release/nimiq_node_avx.node',
-    'build/Release/nimiq_node_avx2.node',
-    'build/Release/nimiq_node_avx512f.node'
-];
-
 gulp.task('eslint', function () {
     const eslint = require('gulp-eslint');
     return gulp.src(sources.all)
@@ -678,19 +659,5 @@ gulp.task('build', gulp.series(
         ),
     )
 ));
-
-// Build packages
-gulp.task('prepare-packages', gulp.series('build-node', async function () {
-    gulp.src(RELEASE_SOURCES).pipe(gulp.dest('packaging/BUILD'));
-    gulp.src(['clients/nodejs/node-ui/**/*']).pipe(gulp.dest('packaging/BUILD/node-ui'));
-    gulp.src(['clients/nodejs/sample.conf']).pipe(gulp.dest('packaging/BUILD/fakeroot/etc/nimiq'));
-    gulp.src(['package.json']).pipe(replace('"architecture": "none"', `"architecture": "${env.architecture}"`)).pipe(gulp.dest('packaging/BUILD'));
-    gulp.src(['clients/nodejs/nimiq']).pipe(replace('node "\\$SCRIPT_PATH/index.js"', '/usr/share/nimiq/{{ cli_entrypoint }}')).pipe(gulp.dest('packaging/BUILD'));
-    gulp.src(['clients/nodejs/index.js', 'clients/nodejs/remote.js', 'clients/nodejs/keytool.js']).pipe(replace('../../dist/node.js', './lib/node.js')).pipe(gulp.dest('packaging/BUILD'));
-    gulp.src(['clients/nodejs/modules/*.js']).pipe(replace('../../../dist/', '../lib/')).pipe(gulp.dest('packaging/BUILD/modules'));
-    gulp.src(['node_modules/**/*'], {base: '.', dot: true }).pipe(gulp.dest('packaging/BUILD'));
-    gulp.src(RELEASE_LIB).pipe(gulp.dest('packaging/BUILD/lib'));
-    gulp.src(RELEASE_ADDONS).pipe(gulp.dest('packaging/BUILD/build'));
-}));
 
 gulp.task('default', gulp.series('build'));

--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
     "package_name": "nimiq",
     "version": "1.5.8-1",
     "init": "systemd",
-    "architecture": "none",
+    "architecture": "amd64",
     "install_strategy": "copy",
     "description": "Nimiq node.js client",
     "maintainer": "The Nimiq Core Development Team <info@nimiq.com>",

--- a/package.json
+++ b/package.json
@@ -70,6 +70,7 @@
     "json5": "^2.1.0",
     "lodash.merge": "^4.6.2",
     "nan": "^2.16.0",
+    "node-deb": "^0.10.7",
     "ws": "^7.0.1"
   },
   "devDependencies": {
@@ -108,7 +109,6 @@
     "karma-safari-launcher": "^1.0.0",
     "merge2": "^1.2.1",
     "minimist": "^1.2.0",
-    "node-deb": "^0.10.4",
     "node-gyp": "^5.0.1",
     "sri-toolbox": "^0.2.0",
     "tslint": "^5.12.1",

--- a/package.json
+++ b/package.json
@@ -8,8 +8,6 @@
   "scripts": {
     "prepare": "gulp build-node",
     "build": "gulp build",
-    "build-deb": "gulp --architecture=`dpkg --print-architecture` prepare-packages && cd packaging/BUILD && mv fakeroot/etc/nimiq/sample.conf fakeroot/etc/nimiq/nimiq.conf && node-deb --no-default-package-dependencies -- node *.js VERSION build/ lib/ modules/ node-ui/ && mv *.deb ../../dist/",
-    "build-rpm": "gulp --architecture=`arch` prepare-packages && cd packaging && mv BUILD/fakeroot/etc/nimiq/sample.conf BUILD/fakeroot/etc/nimiq/nimiq.conf && rpmbuild -bb SPECS/nimiq.spec && mv RPMS/x86_64/*.rpm ../dist",
     "esdoc": "esdoc",
     "test": "jasmine && karma start",
     "test-node": "jasmine",

--- a/packaging/build-package.sh
+++ b/packaging/build-package.sh
@@ -1,0 +1,53 @@
+#!/bin/bash
+
+set -e
+
+# Check that at least one parameter (type of package to build) has been specified
+if [[ -z $1 ]];
+then
+  echo "Error: must specify if building a deb or rpm package"
+  exit 1
+fi
+
+NODE_BIN=$(which node)
+HOME_PATH=$(dirname "$0")/..
+
+# Make sure we start from the right path
+cd ${HOME_PATH}
+
+# Create the directories where all files will be copied
+mkdir packaging/BUILD/{fakeroot/etc/nimiq/,modules/,lib/,build/}
+
+# Copy files that need to go verbatim into the package
+cp dist/VERSION ${NODE_BIN} packaging/BUILD/
+cp -r clients/nodejs/node-ui packaging/BUILD/
+cp clients/nodejs/sample.conf packaging/BUILD/fakeroot/etc/nimiq/
+cp package.json packaging/BUILD/
+cp -r node_modules packaging/BUILD/
+cp dist/node.* dist/worker-* dist/web.* packaging/BUILD/lib/
+cp build/Release/nimiq_*.node packaging/BUILD/build
+mv packaging/BUILD/fakeroot/etc/nimiq/sample.conf packaging/BUILD/fakeroot/etc/nimiq/nimiq.conf
+
+# Copy files that need to be modified from their original form
+for i in $(ls clients/nodejs/ | grep 'js$');
+  do sed 's|../../dist/node.js|./lib/node.js|' clients/nodejs/${i} > packaging/BUILD/${i}
+done
+
+for i in $(ls clients/nodejs/modules/);
+  do sed 's|../../../dist/|../lib/|' clients/nodejs/modules/${i} > packaging/BUILD/modules/${i}
+done
+
+# Format-specific steps to finally build the binary package
+if [ "$1" == "deb" ]
+then
+  sed 's|node "$SCRIPT_PATH/index.js"|/usr/share/nimiq/app/node "/usr/share/nimiq/app/index.js"|' clients/nodejs/nimiq > packaging/BUILD/nimiq
+  cd packaging/BUILD
+  ../../node_modules/.bin/node-deb --no-default-package-dependencies -- node *.js VERSION build/ lib/ modules/ node-ui/
+  mv *.deb ../../dist/
+elif [ "$1" == "rpm" ]
+then
+  sed 's|node "$SCRIPT_PATH/index.js"|/usr/share/nimiq/node "/usr/share/nimiq/index.js"|' clients/nodejs/nimiq > packaging/BUILD/nimiq
+  cd packaging
+  rpmbuild -bb SPECS/nimiq.spec
+  mv RPMS/x86_64/*.rpm ../dist
+fi

--- a/yarn.lock
+++ b/yarn.lock
@@ -5638,7 +5638,7 @@ nice-try@^1.0.4:
   resolved "https://registry.yarnpkg.com/nice-try/-/nice-try-1.0.5.tgz#a3378a7696ce7d223e88fc9b764bd7ef1089e366"
   integrity sha512-1nh45deeb5olNY7eX82BkPO7SSxR5SSYJiPTrTdFUVYwAl8CKMA5N9PjTYkHiRjisVcxcQ1HXdLhx2qxxJzLNQ==
 
-node-deb@^0.10.4:
+node-deb@^0.10.7:
   version "0.10.7"
   resolved "https://registry.yarnpkg.com/node-deb/-/node-deb-0.10.7.tgz#8b0c19e7ee0ea72b2d861cd9ea32aec4c231bb9e"
   integrity sha512-MEXsGSjNcf7HVkaId8wIBjmEa5l1FuLR+KYr84n4RIDj9gDF9VwxU0gvV+9fUYYmZZ9bP+1MvDDOz/ELrMizAA==


### PR DESCRIPTION
This PR fixes (with one exception, see below) the issue described in #603.

To fix #603, the way packages were created suffered an important change: before all the preparation/copy of files for the package was done via `gulp`, but since `gulp` itself is a dev dependency, this wouldn't work once the dev dependencies were removed from the package creation process, so now all that was previously done at the `gulp` level is done with a new shell script (and since a shell script is more flexible, I included what was previously done via `package.json`'s scripts so that the whole package building process is done in one step and within only that bash script).

There was one other dev dependency that is used for package creation: [node-deb](https://github.com/heartsucker/node-deb), since this one would require a very big effort to replace, I'm moving it to be a non-dev dependency (it is still a good trade-off since `node-deb` is tiny and the rest of the dev dependencies are huge) but it should be replaced at some point (I've created issue #629 so that we don't forget).

