### PR TITLE
Add new RPC methods

### DIFF
--- a/clients/nodejs/modules/JsonRpcServer.js
+++ b/clients/nodejs/modules/JsonRpcServer.js
@@ -103,6 +103,7 @@ class JsonRpcServer {
         this._methods.set('getTransactionByBlockHashAndIndex', this.getTransactionByBlockHashAndIndex.bind(this));
         this._methods.set('getTransactionByBlockNumberAndIndex', this.getTransactionByBlockNumberAndIndex.bind(this));
         this._methods.set('getTransactionByHash', this.getTransactionByHash.bind(this));
+        this._methods.set('getTransactionByHash2', this.getTransactionByHash2.bind(this));
         this._methods.set('getTransactionReceipt', this.getTransactionReceipt.bind(this));
         this._methods.set('getTransactionsByAddress', this.getTransactionsByAddress.bind(this));
         this._methods.set('mempoolContent', this.mempoolContent.bind(this));
@@ -343,6 +344,18 @@ class JsonRpcServer {
         const tx = await this._client.getTransaction(hash, blockHash, blockHeight);
         if (tx) {
             return this._transactionDetailsToObj(tx);
+        }
+        return null;
+    }
+
+    async getTransactionByHash2(hash) {
+        return this._getTransactionByHash2(Nimiq.Hash.fromString(hash));
+    }
+
+    async _getTransactionByHash2(hash, blockHash, blockHeight) {
+        const tx = await this._client.getTransaction(hash, blockHash, blockHeight);
+        if (tx) {
+            return this._transactionDetailsToObj2(tx);
         }
         return null;
     }
@@ -802,6 +815,33 @@ class JsonRpcServer {
             data: Nimiq.BufferUtils.toHex(tx.data.raw) || null,
             proof: Nimiq.BufferUtils.toHex(tx.proof.raw) || null,
             flags: tx.flags,
+        };
+    }
+
+    /**
+     * @param {Client.TransactionDetails} tx
+     * @private
+     */
+    _transactionDetailsToObj2(tx) {
+        return {
+            hash: tx.transactionHash.toHex(),
+            blockHash: tx.blockHash ? tx.blockHash.toHex() : undefined,
+            blockNumber: tx.blockHeight,
+            timestamp: tx.timestamp,
+            confirmations: tx.confirmations,
+            from: tx.sender.toHex(),
+            fromAddress: tx.sender.toUserFriendlyAddress(),
+            fromType: tx.senderType,
+            to: tx.recipient.toHex(),
+            toAddress: tx.recipient.toUserFriendlyAddress(),
+            toType: tx.recipientType,
+            value: tx.value,
+            fee: tx.fee,
+            data: Nimiq.BufferUtils.toHex(tx.data.raw) || null,
+            proof: Nimiq.BufferUtils.toHex(tx.proof.raw) || null,
+            flags: tx.flags,
+            validityStartHeight: tx.validityStartHeight,
+            networkId: tx.network,
         };
     }
 

--- a/clients/nodejs/modules/JsonRpcServer.js
+++ b/clients/nodejs/modules/JsonRpcServer.js
@@ -158,7 +158,7 @@ class JsonRpcServer {
      */
     static _authenticate(req, res, username, password) {
         if (username && password && req.headers.authorization !== `Basic ${btoa(`${username}:${password}`)}`) {
-            res.writeHead(401, {'WWW-Authenticate': 'Basic realm="Use user-defined username and password to access the JSON-RPC API." charset="UTF-8"'});
+            res.writeHead(401, { 'WWW-Authenticate': 'Basic realm="Use user-defined username and password to access the JSON-RPC API." charset="UTF-8"' });
             res.end();
             return false;
         }
@@ -488,7 +488,7 @@ class JsonRpcServer {
         try {
             address = Nimiq.Address.fromString(addressStr);
             extraData = Nimiq.BufferUtils.fromHex(extraDataHex);
-        } catch (e) {}
+        } catch (e) { }
         const block = await this._miner.getNextBlock(address, extraData);
         if (!block) {
             const e = new Error('Cannot create work template, check state before requesting work.');
@@ -510,7 +510,7 @@ class JsonRpcServer {
         try {
             address = Nimiq.Address.fromString(addressStr);
             extraData = Nimiq.BufferUtils.fromHex(extraDataHex);
-        } catch (e) {}
+        } catch (e) { }
         const block = await this._miner.getNextBlock(address, extraData);
         if (!block) {
             const e = new Error('Cannot create work template, check state before requesting work.');
@@ -550,7 +550,7 @@ class JsonRpcServer {
         /** @type {Block} */
         const block = Nimiq.Block.unserialize(Nimiq.BufferUtils.fromHex(blockHex));
         if (!block.header.bodyHash.equals(block.body.hash())) throw new Error('Submitted invalid block: bodyHash and body.hash() mismatch');
-        return this._miner.onWorkerShare({hash: await block.header.pow(), nonce: block.header.nonce, block});
+        return this._miner.onWorkerShare({ hash: await block.header.pow(), nonce: block.header.nonce, block });
     }
 
     /*
@@ -778,7 +778,7 @@ class JsonRpcServer {
             value: tx.value,
             fee: tx.fee,
             data: Nimiq.BufferUtils.toHex(tx.data) || null,
-            flags: tx.flags
+            flags: tx.flags,
         };
     }
 
@@ -801,7 +801,7 @@ class JsonRpcServer {
             fee: tx.fee,
             data: Nimiq.BufferUtils.toHex(tx.data.raw) || null,
             proof: Nimiq.BufferUtils.toHex(tx.proof.raw) || null,
-            flags: tx.flags
+            flags: tx.flags,
         };
     }
 
@@ -847,7 +847,7 @@ class JsonRpcServer {
                 res.writeHead(400);
                 res.end(JSON.stringify({
                     'jsonrpc': '2.0',
-                    'error': {'code': -32600, 'message': 'Invalid Request'},
+                    'error': { 'code': -32600, 'message': 'Invalid Request' },
                     'id': null
                 }));
                 return;
@@ -861,7 +861,7 @@ class JsonRpcServer {
                 if (!msg || msg.jsonrpc !== '2.0' || !msg.method) {
                     result.push({
                         'jsonrpc': '2.0',
-                        'error': {'code': -32600, 'message': 'Invalid Request'},
+                        'error': { 'code': -32600, 'message': 'Invalid Request' },
                         'id': msg ? msg.id : null
                     });
                     continue;
@@ -870,7 +870,7 @@ class JsonRpcServer {
                     Nimiq.Log.w(JsonRpcServer, 'Unknown method called', msg.method);
                     result.push({
                         'jsonrpc': '2.0',
-                        'error': {'code': -32601, 'message': 'Method not found'},
+                        'error': { 'code': -32601, 'message': 'Method not found' },
                         'id': msg.id
                     });
                     continue;
@@ -878,13 +878,13 @@ class JsonRpcServer {
                 try {
                     const methodRes = await this._methods.get(msg.method).apply(null, msg.params instanceof Array ? msg.params : [msg.params]);
                     if (typeof msg.id === 'string' || Number.isInteger(msg.id)) {
-                        result.push({'jsonrpc': '2.0', 'result': methodRes, 'id': msg.id});
+                        result.push({ 'jsonrpc': '2.0', 'result': methodRes, 'id': msg.id });
                     }
                 } catch (e) {
                     Nimiq.Log.d(JsonRpcServer, e.stack);
                     result.push({
                         'jsonrpc': '2.0',
-                        'error': {'code': e.code || 1, 'message': e.message || e.toString()},
+                        'error': { 'code': e.code || 1, 'message': e.message || e.toString() },
                         'id': msg.id
                     });
                 }

--- a/src/main/generic/api/TransactionDetails.js
+++ b/src/main/generic/api/TransactionDetails.js
@@ -88,7 +88,7 @@ Client.TransactionDetails = class TransactionDetails {
     /** @type {{raw: Uint8Array}} */
     get proof() {
         const o = Account.TYPE_MAP.get(this.senderType).proofToPlain(this._transaction.proof);
-        o.raw =  this._transaction.proof;
+        o.raw = this._transaction.proof;
         return o;
     }
 


### PR DESCRIPTION
- JsonRpcServer: Add method to get an accounts tree chunk
  - Add RPC method to get an accounts tree chunk: `getAccountsTreeChunk`. The method receives as `string arguments` the block hash on which the snapshot will be taken and the `startPrefix` of the accounts tree chunk. Then it returns an `AccountsTreeChunk` object.
- JsonRpcServer: Add new RPC method to get more transaction details
  - Add new RPC method (`getTransactionByHash2`) that returns more fields than the `getTransactionByHash` method. The added fields are:
    - `toType`
    - `fromType`
    - `validityStartHeight`
    - `networkId`
- Fix some formatting
  - Fix formatting of these files:
    - `JsonRpcServer.js`
    - `TransactionDetails.js`


## Pull request checklist

- [x] All tests pass. Demo project builds and runs.
- [X] I have resolved any merge conflicts.
