### PR TITLE
Add Content-Type header to RPC responses

### DIFF
--- a/clients/nodejs/modules/JsonRpcServer.js
+++ b/clients/nodejs/modules/JsonRpcServer.js
@@ -55,6 +55,7 @@ class JsonRpcServer {
                 res.end('Nimiq JSON-RPC Server\n');
             } else if (req.method === 'POST') {
                 if (JsonRpcServer._authenticate(req, res, config.username, config.password)) {
+                    res.setHeader('Content-Type', 'application/json');
                     this._onRequest(req, res);
                 }
             } else {


### PR DESCRIPTION
The JSON-RPC server was missing the `Content-Type` response header, which tripped up at least one wallet provider using Nimiq via RPC.