### PR TITLE
Install curl in Docker containers

### DIFF
--- a/docker/deb.Dockerfile
+++ b/docker/deb.Dockerfile
@@ -14,7 +14,7 @@ RUN echo "deb [arch=amd64] http://repo.nimiq.com/deb stable main" > /etc/apt/sou
 
 # Install nimiq and tini
 RUN apt-get update \
-    && apt-get --no-install-recommends -y install nimiq tini \
+    && apt-get --no-install-recommends -y install nimiq tini curl \
     && rm -rf /var/lib/apt/lists/*
 
 # We're going to execute nimiq in the context of its own user, what else?

--- a/docker/git.Dockerfile
+++ b/docker/git.Dockerfile
@@ -47,7 +47,7 @@ FROM node:18-bookworm-slim
 
 # Install tini - a tiny init for containers
 RUN apt-get update \
-    && apt-get --no-install-recommends -y install tini \
+    && apt-get --no-install-recommends -y install tini curl \
     && rm -rf /var/lib/apt/lists/*
 
 # We're going to execute nimiq in the context of its own user, what else?

--- a/docker/local.Dockerfile
+++ b/docker/local.Dockerfile
@@ -45,7 +45,7 @@ FROM node:18-bookworm-slim
 
 # Install tini - a tiny init for containers
 RUN apt-get update \
-    && apt-get --no-install-recommends -y install tini \
+    && apt-get --no-install-recommends -y install tini curl \
     && rm -rf /var/lib/apt/lists/*
 
 # We're going to execute nimiq in the context of its own user, what else?


### PR DESCRIPTION
To do automatic healthchecks with Docker, usually the `curl` command is used to check a certain HTTP endpoint. A curl command is also what Coolify auto-generates (no way to change that part). The healthchecks on my containers where failing because curl was not available in the container. The NodeJS _slim_ container images do not include the `curl` command (it's removed in the last step of that image).

## Pull request checklist

- [x] All tests pass. Demo project builds and runs.
- [x] I have resolved any merge conflicts.
