### PR TITLE
Bump node-gyp to version 10.2.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -107,7 +107,7 @@
     "karma-jasmine": "^4.0.2",
     "karma-safari-launcher": "^1.0.0",
     "merge2": "^1.2.1",
-    "node-gyp": "^9.4.0",
+    "node-gyp": "^10.2.0",
     "sri-toolbox": "^0.2.0",
     "tslint": "^5.12.1",
     "typescript": "^3.3.3",


### PR DESCRIPTION
Bump node-gyp to version >= 10 to fix compilation issues that arose after [distutils was removed from Python in version 3.13](https://github.com/nodejs/node-gyp/issues/2869).