### PR TITLE
Bump jungle-db to 0.11.1

### DIFF
--- a/dist/VERSION
+++ b/dist/VERSION
@@ -1,5 +1,5 @@
 {
-  "code": 21,
-  "name": "Nimiq v1.6.3",
+  "code": 22,
+  "name": "Nimiq v1.6.4",
   "minRequiredVersion": 1
 }

--- a/package.json
+++ b/package.json
@@ -59,7 +59,7 @@
   },
   "gypfile": true,
   "dependencies": {
-    "@nimiq/jungle-db": "^0.11.0",
+    "@nimiq/jungle-db": "^0.11.1",
     "atob": "^2.0.3",
     "bindings": "^1.3.0",
     "btoa": "^1.1.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nimiq/core",
-  "version": "1.6.3",
+  "version": "1.6.4",
   "main": "dist/node.js",
   "types": "dist/types.d.ts",
   "homepage": "https://nimiq.com/",
@@ -38,7 +38,7 @@
   ],
   "node_deb": {
     "package_name": "nimiq",
-    "version": "1.6.3-1",
+    "version": "1.6.4-1",
     "init": "systemd",
     "architecture": "amd64",
     "install_strategy": "copy",

--- a/packaging/SPECS/nimiq.spec
+++ b/packaging/SPECS/nimiq.spec
@@ -4,7 +4,7 @@
 %define _topdir %(echo $PWD)/
 
 Name:           nimiq
-Version:        1.6.3
+Version:        1.6.4
 Release:        1
 Summary:        Nimiq node.js client
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -1048,10 +1048,10 @@
   resolved "https://registry.yarnpkg.com/@nicolo-ribaudo/chokidar-2/-/chokidar-2-2.1.8-no-fsevents.3.tgz#323d72dd25103d0c4fbdce89dadf574a787b1f9b"
   integrity sha512-s88O1aVtXftvp5bCPB7WnmXc5IwOZZ7YPuwNPt+GtOOXpPvad1LfbmjYv+qII7zP6RU2QGnqve27dnLycEnyEQ==
 
-"@nimiq/jungle-db@^0.11.0":
-  version "0.11.0"
-  resolved "https://registry.yarnpkg.com/@nimiq/jungle-db/-/jungle-db-0.11.0.tgz#a4c03c7e9814bc06f4343692f7e14aabdef3e1ee"
-  integrity sha512-Unt3tonnIP1WouwdhOjI2fIVRTAtaCqB5LroftYwchA+JV7f7WrKV8ABThW86QBueOnIZn0ItO03TnIzThHWUw==
+"@nimiq/jungle-db@^0.11.1":
+  version "0.11.1"
+  resolved "https://registry.yarnpkg.com/@nimiq/jungle-db/-/jungle-db-0.11.1.tgz#01b85039f158542c8f83e330f51c332f8717b155"
+  integrity sha512-4t1eATxAMOjTNRAF0t6dADY4pHQ6owB3CG4g33/m43+eLx5IFaYKvCJ5uuT2FRqTG5hnqyCNbSZrE8cBurFt4A==
   dependencies:
     atob "^2.0.3"
     btoa "^1.1.2"


### PR DESCRIPTION
Bump jungle-db version to 0.11.1, which fixes a snapshot corruption issue that affects the PoS migration.

Bump package version to 1.6.4.